### PR TITLE
Changed to iterator

### DIFF
--- a/src/erlport/erlproto.py
+++ b/src/erlport/erlproto.py
@@ -127,7 +127,7 @@ class Port(object):
         data = self._read_data(self.packet)
         length, = unpack(self._format, data)
         data = self._read_data(length)
-        return decode(data)[0]
+        return decode(data)
 
     def write(self, message):
         """Write outgoing message."""

--- a/src/erlport/erlterms.py
+++ b/src/erlport/erlterms.py
@@ -120,19 +120,19 @@ def decode_term(it,
             return ord(it.next())
         elif tag == 98:
             # INTEGER_EXT
-            i, = unpack(">i", islice(it, 0, 4))
+            i, = unpack(">i", ''.join(islice(it, 0, 4)))
             return i
         elif tag == 106:
             # NIL_EXT
             return []
         elif tag == 107:
             # STRING_EXT
-            length, = unpack(">H", islice(it, 0, 2))
+            length, = unpack(">H", ''.join(islice(it, 0, 2)))
             string = islice(it, 0, length)
             return [ord(i) for i in string]
         elif tag == 108:
             # LIST_EXT
-            length, = unpack(">I", islice(it, 0, 4))
+            length, = unpack(">I", ''.join(islice(it, 0, 4)))
             lst = []
             while length > 0:
                 term = decode_term(it)
@@ -141,11 +141,11 @@ def decode_term(it,
             return lst
         elif tag == 109:
             # BINARY_EXT
-            length, = unpack(">I", islice(it, 0, 4))
+            length, = unpack(">I", ''.join(islice(it, 0, 4)))
             return islice(it, 0, length)
         elif tag == 100:
             # ATOM_EXT
-            length, = unpack(">H", islice(it, 0, 2))
+            length, = unpack(">H", ''.join(islice(it, 0, 2)))
             name = islice(it, 0, length)
             if name == "true":
                 return True
@@ -159,7 +159,7 @@ def decode_term(it,
             if tag == 104:
                 arity = ord(it.next())
             else:
-                arity, = unpack(">I", islice(it, 0, 4))
+                arity, = unpack(">I", ''.join(islice(it, 0, 4)))
             lst = []
             while arity > 0:
                 term = decode_term(it)
@@ -168,7 +168,7 @@ def decode_term(it,
             return tuple(lst)
         elif tag == 70:
             # NEW_FLOAT_EXT
-            term, = unpack(">d", islice(it, 0, 8))
+            term, = unpack(">d", ''.join(islice(it, 0, 8)))
             return term
         elif tag == 99:
             # FLOAT_EXT
@@ -176,9 +176,9 @@ def decode_term(it,
         elif tag == 110 or tag == 111:
             # SMALL_BIG_EXT, LARGE_BIG_EXT
             if tag == 110:
-                length, sign = unpack(">BB", islice(it, 0, 2))
+                length, sign = unpack(">BB", ''.join(islice(it, 0, 2)))
             else:
-                length, sign = unpack(">IB", islice(it, 0, 5))
+                length, sign = unpack(">IB", ''.join(islice(it, 0, 5)))
             n = 0
             l = islice(it, 0, length-1)
             l.reverse()
@@ -189,7 +189,7 @@ def decode_term(it,
             return n
         elif tag == 77:
             # BIT_BINARY_EXT
-            length, bits = unpack(">IB", islice(it, 0, 5))
+            length, bits = unpack(">IB", ''.join(islice(it, 0, 5)))
             return BitBinary(islice(it, 0, 5), bits)
     except StopIteration :
         raise ValueError("unsupported data tag: %i" % list(it))

--- a/src/erlport/erlterms.py
+++ b/src/erlport/erlterms.py
@@ -181,7 +181,7 @@ def decode_term(it,
             else:
                 length, sign = unpack(">IB", ''.join(islice(it, 0, 5)))
             n = 0
-            l = ''.join(islice(it, 0, length-1))
+            l = ''.join(islice(it, 0, length))
             l = l[::-1]
             for i in array('B', l):
                 n = (n << 8) | i

--- a/src/erlport/erlterms.py
+++ b/src/erlport/erlterms.py
@@ -153,7 +153,7 @@ def decode_term(it,
                 return False
             elif name == "none":
                 return None
-            return Atom(''.join(name))
+            return Atom(name)
         elif tag == 104 or tag == 105:
             # SMALL_TUPLE_EXT, LARGE_TUPLE_EXT
             if tag == 104:

--- a/src/erlport/erlterms.py
+++ b/src/erlport/erlterms.py
@@ -182,7 +182,7 @@ def decode_term(it,
                 length, sign = unpack(">IB", ''.join(islice(it, 0, 5)))
             n = 0
             l = ''.join(islice(it, 0, length-1))
-            l.reverse()
+            l = l[::-1]
             for i in array('B', l):
                 n = (n << 8) | i
             if sign:

--- a/src/erlport/erlterms.py
+++ b/src/erlport/erlterms.py
@@ -153,7 +153,7 @@ def decode_term(it,
                 return False
             elif name == "none":
                 return None
-            return Atom(name)
+            return Atom(''.join(name))
         elif tag == 104 or tag == 105:
             # SMALL_TUPLE_EXT, LARGE_TUPLE_EXT
             if tag == 104:

--- a/src/erlport/erlterms.py
+++ b/src/erlport/erlterms.py
@@ -128,7 +128,7 @@ def decode_term(it,
         elif tag == 107:
             # STRING_EXT
             length, = unpack(">H", ''.join(islice(it, 0, 2)))
-            string = islice(it, 0, length)
+            string = ''.join(islice(it, 0, length))
             return [ord(i) for i in string]
         elif tag == 108:
             # LIST_EXT
@@ -142,11 +142,11 @@ def decode_term(it,
         elif tag == 109:
             # BINARY_EXT
             length, = unpack(">I", ''.join(islice(it, 0, 4)))
-            return islice(it, 0, length)
+            return ''.join(islice(it, 0, length))
         elif tag == 100:
             # ATOM_EXT
             length, = unpack(">H", ''.join(islice(it, 0, 2)))
-            name = islice(it, 0, length)
+            name = ''.join(islice(it, 0, length))
             if name == "true":
                 return True
             elif name == "false":
@@ -172,7 +172,7 @@ def decode_term(it,
             return term
         elif tag == 99:
             # FLOAT_EXT
-            return float(islice(it, 0, 31).split("\x00", 1)[0])
+            return float(''.join(islice(it, 0, 31)).split("\x00", 1)[0])
         elif tag == 110 or tag == 111:
             # SMALL_BIG_EXT, LARGE_BIG_EXT
             if tag == 110:
@@ -180,7 +180,7 @@ def decode_term(it,
             else:
                 length, sign = unpack(">IB", ''.join(islice(it, 0, 5)))
             n = 0
-            l = islice(it, 0, length-1)
+            l = ''.join(islice(it, 0, length-1))
             l.reverse()
             for i in array('B', l):
                 n = (n << 8) | i
@@ -190,7 +190,7 @@ def decode_term(it,
         elif tag == 77:
             # BIT_BINARY_EXT
             length, bits = unpack(">IB", ''.join(islice(it, 0, 5)))
-            return BitBinary(islice(it, 0, 5), bits)
+            return BitBinary(''.join(islice(it, 0, 5)), bits)
     except StopIteration :
         raise ValueError("unsupported data tag: %i" % list(it))
 

--- a/src/erlport/erlterms.py
+++ b/src/erlport/erlterms.py
@@ -138,6 +138,7 @@ def decode_term(it,
                 term = decode_term(it)
                 lst.append(term)
                 length -= 1
+            ignored = decode_term(it)
             return lst
         elif tag == 109:
             # BINARY_EXT


### PR DESCRIPTION
Changed decode method to work with iterator instead of list.
Slice operation in python have O(N) time complexity in worst case (string[1:]). Therefore large amount of erlang terms takes too much time to proceed. Iterator allows decode in O(1) time.