### PR TITLE
Add list of registered processes to erlport.app

### DIFF
--- a/ebin/erlport.app
+++ b/ebin/erlport.app
@@ -37,5 +37,6 @@
         ruby,
         ruby_options
         ]},
+    {registered, []},
     {applications, [kernel, stdlib]}
     ]}.


### PR DESCRIPTION
This adds `{registered, []}` to _ebin/erlport.app_, which according to the [Erlang documentation](http://www.erlang.org/doc/design_principles/applications.html) is required.

The reason for me adding this is that [relx](https://github.com/erlware/relx) expects `registered` to be present and fails when it's not.
