### PR TITLE
Removed catch-all receive clause on version checking.

### DIFF
--- a/src/erlport_options.erl
+++ b/src/erlport_options.erl
@@ -317,9 +317,7 @@ filter_invalid_env(_Env) ->
 receive_version(Port) ->
     Out = receive
         {Port, {data, {eol, Version}}} ->
-            Version;
-        _ ->
-            "ERROR"
+            Version
     after
         ?TIMEOUT ->
             "TIMEOUT"


### PR DESCRIPTION
The point is this code runs from another process, which can have its own messages in a queue, thus second clause will not allow erlport to check version and affect starting process. If something goes wrong timeout is still there.
