### PR TITLE
use uuid4 for message ids

### DIFF
--- a/priv/python2/erlport/erlang.py
+++ b/priv/python2/erlport/erlang.py
@@ -29,14 +29,16 @@ from __future__ import with_statement
 
 __author__ = "Dmitry Vasiliev <dima@hlabs.org>"
 
+from contextlib import contextmanager
+from inspect import getargspec
 import sys
 from sys import exc_info
 from traceback import extract_tb
-from inspect import getargspec
 from threading import Lock
-from contextlib import contextmanager
+import uuid
 
 from erlport import Atom
+
 
 class Error(Exception):
     """ErlPort Error."""
@@ -96,20 +98,9 @@ class Responses(object):
 
 class MessageId(object):
 
-    def __init__(self):
-        self.__ids = set()
-        self.__lock = Lock()
-
     @contextmanager
     def __call__(self):
-        with self.__lock:
-            mid = max(self.__ids) + 1 if self.__ids else 1
-            self.__ids.add(mid)
-        try:
-            yield mid
-        finally:
-            with self.__lock:
-                self.__ids.remove(mid)
+        yield uuid.uuid4().int
 
 class MessageHandler(object):
 

--- a/priv/python3/erlport/erlang.py
+++ b/priv/python3/erlport/erlang.py
@@ -25,12 +25,13 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+from contextlib import contextmanager
+from inspect import getargspec
 import sys
 from sys import exc_info
 from traceback import extract_tb
-from inspect import getargspec
 from threading import Lock
-from contextlib import contextmanager
+import uuid
 
 from erlport import Atom
 
@@ -92,20 +93,9 @@ class Responses(object):
 
 class MessageId(object):
 
-    def __init__(self):
-        self.__ids = set()
-        self.__lock = Lock()
-
     @contextmanager
     def __call__(self):
-        with self.__lock:
-            mid = max(self.__ids) + 1 if self.__ids else 1
-            self.__ids.add(mid)
-        try:
-            yield mid
-        finally:
-            with self.__lock:
-                self.__ids.remove(mid)
+        yield uuid.uuid4().int
 
 class MessageHandler(object):
 

--- a/priv/ruby1.8/erlport/erlang.rb
+++ b/priv/ruby1.8/erlport/erlang.rb
@@ -36,39 +36,6 @@ include ErlPort::ErlTerm
 require 'securerandom'
 
 
-
-module SecureRandom
-  # Backport of missing SecureRandom methods from 1.9
-  class << self
-    def method_missing(method_sym, *arguments, &block)
-      case method_sym
-      when :urlsafe_base64
-        r19_urlsafe_base64(*arguments)
-      when :uuid
-        r19_uuid(*arguments)
-      else
-        super
-      end
-    end
-
-    private
-    def r19_urlsafe_base64(n=nil, padding=false)
-      s = [random_bytes(n)].pack("m*")
-      s.delete!("\n")
-      s.tr!("+/", "-_")
-      s.delete!("=") if !padding
-      s
-    end
-
-    def r19_uuid
-      ary = random_bytes(16).unpack("NnnnnN")
-      ary[2] = (ary[2] & 0x0fff) | 0x4000
-      ary[3] = (ary[3] & 0x3fff) | 0x8000
-      "%08x-%04x-%04x-%04x-%04x%08x" % ary
-    end
-  end
-end
-
 module ErlPort
 module Erlang
 
@@ -312,7 +279,7 @@ module Erlang
 
     class MessageId
         def generate &code
-            code.call SecureRandom.uuid
+            code.call SecureRandom.random_number(2 << 128)
         end
     end
 end

--- a/priv/ruby1.8/erlport/erlang.rb
+++ b/priv/ruby1.8/erlport/erlang.rb
@@ -33,6 +33,42 @@ require "erlport/stdio"
 
 include ErlPort::ErlTerm
 
+require 'securerandom'
+
+
+
+module SecureRandom
+  # Backport of missing SecureRandom methods from 1.9
+  class << self
+    def method_missing(method_sym, *arguments, &block)
+      case method_sym
+      when :urlsafe_base64
+        r19_urlsafe_base64(*arguments)
+      when :uuid
+        r19_uuid(*arguments)
+      else
+        super
+      end
+    end
+
+    private
+    def r19_urlsafe_base64(n=nil, padding=false)
+      s = [random_bytes(n)].pack("m*")
+      s.delete!("\n")
+      s.tr!("+/", "-_")
+      s.delete!("=") if !padding
+      s
+    end
+
+    def r19_uuid
+      ary = random_bytes(16).unpack("NnnnnN")
+      ary[2] = (ary[2] & 0x0fff) | 0x4000
+      ary[3] = (ary[3] & 0x3fff) | 0x8000
+      "%08x-%04x-%04x-%04x-%04x%08x" % ary
+    end
+  end
+end
+
 module ErlPort
 module Erlang
 
@@ -275,24 +311,8 @@ module Erlang
     end
 
     class MessageId
-        def initialize
-            @ids = Set.new
-            @lock = Mutex.new
-        end
-
         def generate &code
-            mid = @lock.synchronize {
-                mid = (not @ids.empty?)? @ids.max + 1: 1
-                @ids.add(mid)
-                mid
-            }
-            begin
-                code.call mid
-            ensure
-                @lock.synchronize {
-                    @ids.delete(mid)
-                }
-            end
+            code.call SecureRandom.uuid
         end
     end
 end


### PR DESCRIPTION
If you're running a pool of erlport ports, it's possible to generate duplicate message ids.
This change swaps out the default messasge id implemetation (which is lock heavy) in favor of uuids.

I'm curious what you think about this; the implementation is much simpler, uses no locks and is much more reliable. If you like this, I can update the python 3 an ruby versions and resubmit the PR.

I understand that you were being very efficient by using small numbers (the smallest possible, really), but I'm running 600 long-running python processes per server and while the old algorithm crashed pretty regularly, this hasn't crashed once with over two weeks of around-the-clock testing. 

Performance hasn't changed unless I run microbenchmarks, then it's very slightly slower.
