### PR TITLE
Fix compatibility of make test in OSX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ $(TESTDIR):
 	@mkdir $@
 
 $(TESTDIR)/erlport.app:
-	@cp -l ebin/erlport.app $(TESTDIR)
+	@ln ebin/erlport.app $(TESTDIR)
 
 test: erlang-test
 	@for folder in $(VERSIONS); do \


### PR DESCRIPTION
OSX `cp` command doesn't have `-l` option.
use `ln` instead of `cp -l` for OSX compatibility