### PR TITLE
Fix wrong ruby negative int array encoded value

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ $(TESTDIR):
 	@mkdir $@
 
 $(TESTDIR)/erlport.app:
-	@cp -l ebin/erlport.app $(TESTDIR)
+	@ln ebin/erlport.app $(TESTDIR)
 
 test: erlang-test
 	@for folder in $(VERSIONS); do \

--- a/priv/ruby1.8/erlport/erlterms.rb
+++ b/priv/ruby1.8/erlport/erlterms.rb
@@ -353,7 +353,7 @@ module ErlTerm
                 if term.empty?
                     return "j"
                 elsif length <= 65535
-                    if term.index{|i| not i.is_a? Integer or i > 255} == nil
+                    if term.index{|i| not i.is_a? Integer or i > 255 or i < 0} == nil
                         return [107, length].pack("Cn") + term.pack("C*")
                     end
                 elsif length > 4294967295

--- a/priv/ruby1.9/erlport/erlterms.rb
+++ b/priv/ruby1.9/erlport/erlterms.rb
@@ -342,7 +342,7 @@ module ErlTerm
                 if term.empty?
                     return "j"
                 elsif length <= 65535
-                    if term.index{|i| not i.is_a? Integer or i > 255} == nil
+                    if term.index{|i| not i.is_a? Integer or i > 255 or i < 0} == nil
                         return [107, length].pack("Cn") + term.pack("C*")
                     end
                 elsif length > 4294967295

--- a/test/datatype_test_data.erl
+++ b/test/datatype_test_data.erl
@@ -56,7 +56,7 @@ atom_types() ->
     ['', test, 'TEST', true, false, undefined].
 
 list_types() ->
-    [[], [0], [1, 2, 3], [[]], [[], [], []], lists:seq(1, 10000)].
+    [[], [0], [1, 2, 3], [[]], [[], [], []], lists:seq(1, 10000), lists:seq(-10,10)].
 
 improper_list_types() ->
     [[0 | 1], [1, 2, 3 | 4], [head | tail]].


### PR DESCRIPTION
## Issue
#27 

## Changes

In ruby, only treat int array as string if it's ord is > 0.