### PR TITLE
Record behavior change in OTP-19

### DIFF
--- a/src/python.hrl
+++ b/src/python.hrl
@@ -35,7 +35,7 @@
 
 -record(python_options, {
     python = default :: string() | default,
-    cd :: Path :: string(),
+    cd :: Path :: string() | undefined,
     use_stdio = use_stdio :: use_stdio | nouse_stdio,
     compressed = 0 :: 0..9,
     packet = 4 :: 1 | 2 | 4,

--- a/src/ruby.hrl
+++ b/src/ruby.hrl
@@ -35,7 +35,7 @@
 
 -record(ruby_options, {
     ruby = default :: string() | default,
-    cd :: Path :: string(),
+    cd :: Path :: string() | undefined,
     use_stdio = use_stdio :: use_stdio | nouse_stdio,
     compressed = 0 :: 0..9,
     packet = 4 :: 1 | 2 | 4,


### PR DESCRIPTION
After the release of OTP-19, there was change to stdlib (OTP-12719) which means if you have a record field which could be a type or undefined, you now have to explicitly define the ```| undefined``` on field.
 