### PR TITLE
Fix erlang:get_stacktrace() warning that causes building erlport to fail on OTP 21

### DIFF
--- a/test/erlport_test_utils.erl
+++ b/test/erlport_test_utils.erl
@@ -270,7 +270,7 @@ random_name(0) ->
     [];
 random_name(N) ->
     Chars = ?CHARS,
-    I = crypto:rand_uniform(1, tuple_size(Chars) + 1),
+    I = rand:uniform(tuple_size(Chars)),
     [element(I, Chars) | random_name(N - 1)].
 
 get_base_dir() ->


### PR DESCRIPTION
This warning, introduced in OTP 21 is causing things that depend on erlport to fail to build. Normally a warning wouldn't have such an impact but the `rebar.config` has `{erl_opts, [debug_info, warnings_as_errors]}.` which turns the warning into a compile error.

I am not an erlang expert, feedback is welcome on the PR.