### PR TITLE
Fix syntax error with Python 3 by adding `make` for installing

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,3 +1,4 @@
 {deps, []}.
 {erl_opts, [debug_info, warnings_as_errors]}.
 {cover_enabled, true}.
+{post_hooks, [{compile, "make"}]}.


### PR DESCRIPTION
fixes #42
Makefile makes symlinks for python3