### PR TITLE
including compile hook to run makefile automatically by rebar3

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,3 +1,7 @@
 {deps, []}.
 {erl_opts, [debug_info, warnings_as_errors]}.
+
+{pre_hooks,
+        [{"(linux)", compile, "make"}]}.
+        
 {cover_enabled, true}.


### PR DESCRIPTION
Suggestion for issue #55 

I understand that the makefile does all the erlang compilation (without using rebar3), and the rebar.config is quite empty.
Therefore running the makefile as part of the rebar3 compilation duplicates some parts of the build.

However this solution fixes my problem (that I want to use erlport in my rebar3 project), and besides having some warnings it seems safe to me.

