### PR TITLE
error returns stacktrace string instead of traceback object

### DIFF
--- a/priv/python3/erlport/erlang.py
+++ b/priv/python3/erlport/erlang.py
@@ -28,7 +28,7 @@
 from inspect import getargspec
 import sys
 from sys import exc_info
-from traceback import extract_tb
+from traceback import extract_tb, format_list
 from threading import Lock
 import uuid
 
@@ -236,12 +236,16 @@ class MessageHandler(object):
             exc = Atom(bytes("%s.%s" % (t.__module__, t.__name__), "utf-8"))
             exc_tb = extract_tb(tb)
             exc_tb.reverse()
-            error = Atom(b"python"), exc, str(val), exc_tb
+            decoded_tb = self._decode_traceback(exc_tb)
+            error = Atom(b"python"), exc, str(val), decoded_tb
             if mid is not None:
                 result = Atom(b"e"), mid, error
             else:
                 result = Atom(b"e"), error
             self.port.write(result)
+            
+    def _decode_traceback(self, stack_summary):
+        return bytes(''.join(format_list(stack_summary)), "utf-8")
 
 def setup_api_functions(handler):
     global call, cast, self, make_ref


### PR DESCRIPTION
**What used to be:**
Upon Python errors Erlang receives an opaque traceback object as binary data. It can be decoded to ASCII as readable text, but it has to be done manually and the non-text bytes obstruct readability.

**With this modification:**
Erlang now receives the text representation of the traceback as readable binary string.
Better for debugging python processes, better for displaying meaningful error messages to users.