### PR TITLE
erlang:get_stacktrace/0 is deprecated.

### DIFF
--- a/src/erlport.erl
+++ b/src/erlport.erl
@@ -388,9 +388,8 @@ call_mfa(Module, Function, Args) ->
                 when is_atom(Language) andalso is_atom(Type)
                 andalso is_list(Trace) ->
             {error, Error};
-        Type:Reason ->
-            Trace = erlang:get_stacktrace(),
-            {error, {erlang, Type, Reason, Trace}}
+        Type:Reason:Stacktrace ->
+            {error, {erlang, Type, Reason, Stacktrace}}
     end.
 
 %%


### PR DESCRIPTION
This fixes the current build error in OTP 23/24+.